### PR TITLE
Disabling jsx-a11y/label-has-for

### DIFF
--- a/programs/lint/.eslintrc.json
+++ b/programs/lint/.eslintrc.json
@@ -25,6 +25,7 @@
     "import/no-unresolved": 0,
     "import/prefer-default-export": 0,
     "indent": [2, 2, { "SwitchCase": 1 }],
+    "jsx-a11y/label-has-for": 0,
     "no-console": 0,
     "no-else-return": 0,
     "no-multiple-empty-lines": ["error", { "max": 1 }],


### PR DESCRIPTION
It le sucks. It classes this as invalid because it wants an `htmlFor` prop on the label, which is le bullshit.

``` javascript
<label>
  Hello
  <input type="text" />
</label>
```

I agree with the rule if the label is next to the input (as opposed to the input being a child), but it rustles my jimmies that it wants me to add an id to a nested element like this and then reference it.

@iZettle/web 🍩 🇫🇷 
