### PR TITLE
add sort imports rule

### DIFF
--- a/programs/lint/.eslintrc.json
+++ b/programs/lint/.eslintrc.json
@@ -43,6 +43,11 @@
     "react/prefer-stateless-function": 1,
     "react/prop-types": 0,
     "react/no-string-refs": ["warn"],
-    "semi": [2, "never"]
+    "semi": [2, "never"],
+    "sort-imports": ["error", {
+      "ignoreCase": false,
+      "ignoreMemberSort": false,
+      "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
+    }]
   }
 }


### PR DESCRIPTION
Enforce sorting imports a->z

```
# http://eslint.org/docs/rules/sort-imports
import 'module-without-export.js';
import * as foo from 'foo.js';
import * as bar from 'bar.js';
import {alpha, beta} from 'alpha.js';
import {delta, gamma} from 'delta.js';
import a from 'baz.js';
import b from 'qux.js';
```
