### PR TITLE
add rule for parens

### DIFF
--- a/programs/lint/.eslintrc.json
+++ b/programs/lint/.eslintrc.json
@@ -19,6 +19,7 @@
     "react"
   ],
   "rules": {
+    "arrow-parens": ["error", "as-needed"],
     "comma-dangle": ["error", "never"],
     "consistent-return": 0,
     "import/no-extraneous-dependencies": 0,


### PR DESCRIPTION
```javascript

// Bad
const foo = (param) => {
  
}

// Good
const foo = param => {
  
}
```