### PR TITLE
Hot Module Replacement

### DIFF
--- a/config/example.js
+++ b/config/example.js
@@ -5,7 +5,7 @@ module.exports = {
     // the webpack entry file
     entry: "app/ui",
 
-    // wehpack puts its bundles in this dir
+    // webpack puts its bundles in this dir
     output: {
       path: "public",
       filename: "bundle.js"
@@ -26,7 +26,20 @@ module.exports = {
     alias: {
       inugami: "node_modules/inugami/src",
       react: "node_modules/react"
-    }
+    },
+
+    // settings for dev server
+    // See settings: https://webpack.github.io/docs/webpack-dev-server.html
+    devServer: {
+      // e.g. redirect all calls to /api/ to another 
+      // server at port 3100
+      proxy: {
+        '/api/**': {
+          target: 'http://0.0.0.0:3100',
+          secure: false
+        }
+      }
+    }    
 
   },
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+var rhl = require("react-hot-loader")
+
+module.exports = {
+  AppContainer: rhl.AppContainer
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "redux-mock-store": "^1.1.4",
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",
-    "webpack": "^2.1.0-beta.27",
-    "webpack-dev-server": "^2.1.0-beta.11"
+    "webpack": "^2.2.0-rc.2",
+    "webpack-dev-server": "^2.2.0-rc.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@izettle/javascript-env",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "bin": "./bin/cmd.js",
   "main": "index.js",

--- a/programs/compile/dev-server.js
+++ b/programs/compile/dev-server.js
@@ -7,7 +7,8 @@ const port = 8000
 const createDevServer = config => {
   config.entry.unshift(
     `webpack-dev-server/client?http://${host}:${port}`,
-    "webpack/hot/only-dev-server"
+    "webpack/hot/only-dev-server",
+    "react-hot-loader/patch"
   )
   config.output.publicPath = `http://${host}:${port}/`
 

--- a/programs/compile/dev-server.js
+++ b/programs/compile/dev-server.js
@@ -14,14 +14,7 @@ const createDevServer = config => {
 
   config.plugins.push(new webpack.HotModuleReplacementPlugin())
 
-  return new WebpackDevServer(webpack(config), {
-    inline: true,
-    hot: true,
-    stats: {
-      colors: true,
-      chunkModules: false
-    }
-  })
+  return new WebpackDevServer(webpack(config), config.devServer)
 }
 
 const startDevServer = devServer => (

--- a/programs/compile/dev-server.js
+++ b/programs/compile/dev-server.js
@@ -18,7 +18,8 @@ const createDevServer = config => {
     inline: true,
     hot: true,
     stats: {
-      colors: true
+      colors: true,
+      chunkModules: false
     }
   })
 }

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -137,7 +137,6 @@ function createWebpackConfig(args = [], opts = {}) {
       })
     ],
     devServer: {
-      historyApiFallback: true,
       inline: true,
       hot: true,
       stats: {
@@ -147,7 +146,7 @@ function createWebpackConfig(args = [], opts = {}) {
     },
     performance: {
       hints: false
-    }    
+    }
   }
 
   if (opts.entry && opts.output) {

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -135,7 +135,16 @@ function createWebpackConfig(args = [], opts = {}) {
         filename: opts.outputCss || "styles.css",
         allChunks: true
       })
-    ]
+    ],
+    devServer: {
+      historyApiFallback: true,
+      inline: true,
+      hot: true,
+      stats: {
+        colors: true,
+        chunkModules: false
+      }
+    }
   }
 
   if (opts.entry && opts.output) {
@@ -165,6 +174,10 @@ function createWebpackConfig(args = [], opts = {}) {
 
   if (opts.externals) {
     Object.assign(config.externals, opts.externals)
+  }
+
+  if (opts.devServer) {
+    Object.assign(config.devServer, opts.devServer)
   }
 
   return {

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -144,7 +144,10 @@ function createWebpackConfig(args = [], opts = {}) {
         colors: true,
         chunkModules: false
       }
-    }
+    },
+    performance: {
+      hints: false
+    }    
   }
 
   if (opts.entry && opts.output) {

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -3,7 +3,7 @@ const autoprefixer = require("autoprefixer")
 
 const createBabelOptions = args => {
   const babelConfig = {
-    presets: ["es2015-loose", "react", "stage-1"],
+    presets: [["es2015", { "loose" : true }], "react", "stage-1"],
     plugins: []
   }
 


### PR DESCRIPTION
HMR now works. Requires a root project file looking something like this:

```
import React from 'react';
import { render } from 'react-dom';
import { AppContainer } from 'react-hot-loader';

import App from './App'

const rootEl = document.getElementById('root');

render(
  <AppContainer>
    <App />
  </AppContainer>,
  rootEl
);

if (module.hot) {
  module.hot.accept('./App', () => {
    const NewApp = require('./App').default;
    render(
      <AppContainer>
        <NewApp/>
      </AppContainer>,
      rootEl
    );
  });
}
```

I'll take a stab at making HMR work in Kitsune. We might need to pump some dependencies/fix stuff to make HMR work in router context and I'll leave this PR open until then.