### PR TITLE
Sass lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ $ javascript-env lint
 
 You can make the **Atom** `linter-eslint` package use this projects `.eslintrc` file by putting `./node_modules/javascript-env/programs/lint/.eslintrc` into the `.eslintrc Path` text field.
 
+### sasslint
+Uses `sass-lint` and the `programs/sasslint/.sass-lint.yml` rule file. Will check linting on all files named `*.scss` and `*.sass` except files in `node_modules`. Any arguments supplied will just be passed to sass-lint.
+
+Run it like 
+
+```
+$ javascript-env sasslint
+```
+
 ### compile - 'cause configuring webpack is a pain
 
 Gives us the ability to use es2015 and jsx without the hassle of setting up and configuring seventyeleven packages.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@izettle/javascript-env",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "",
   "bin": "./bin/cmd.js",
   "main": "index.js",
@@ -51,6 +51,7 @@
     "react-dom": "^15.4.0",
     "react-hot-loader": "^3.0.0-beta.6",
     "redux-mock-store": "^1.1.4",
+    "sass-lint": "^1.10.2",
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",
     "webpack": "^2.1.0-beta.27",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@izettle/javascript-env",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "",
   "bin": "./bin/cmd.js",
   "main": "index.js",

--- a/programs/index.js
+++ b/programs/index.js
@@ -1,3 +1,4 @@
 module.exports.compile = require("./compile")
 module.exports.lint = require("./lint")
 module.exports.test = require("./test")
+module.exports.sasslint = require("./sasslint")

--- a/programs/sasslint/.sass-lint.yml
+++ b/programs/sasslint/.sass-lint.yml
@@ -1,0 +1,94 @@
+options:
+  formatter: stylish
+files:
+  include: '**/*.s+(a|c)ss'
+  ignore: 'node_modules/**/*.s+(a|c)ss'
+rules:
+  # Extends
+  extends-before-mixins: 1
+  extends-before-declarations: 1
+  placeholder-in-extend: 1
+
+  # Mixins
+  mixins-before-declarations: 0
+
+  # Line Spacing
+  one-declaration-per-line: 1
+  empty-line-between-blocks: 1
+  single-line-per-selector: 1
+
+  # Disallows
+  no-color-keywords: 0
+  no-color-literals: 0
+  no-css-comments: 1
+  no-debug: 1
+  no-duplicate-properties: 1
+  no-empty-rulesets: 1
+  no-extends: 0
+  no-ids: 1
+  no-important: 0
+  no-invalid-hex: 1
+  no-mergeable-selectors: 1
+  no-misspelled-properties: 1
+  no-qualifying-elements: 1
+  no-trailing-whitespace: 1
+  no-trailing-zero: 1
+  no-transition-all: 0
+  no-url-protocols: 0
+  no-url-domains: 0
+  no-vendor-prefixes: 1
+  no-warn: 1
+  property-units: 0
+
+  # Nesting
+  force-attribute-nesting: 1
+  force-element-nesting: 0
+  force-pseudo-nesting: 0
+
+  # Name Formats
+  class-name-format:
+    - 2
+    -
+      allow-leading-underscore: false
+      convention: ^[A-Za-z-]+$
+  function-name-format: 1
+  id-name-format: 0
+  mixin-name-format: 0
+  placeholder-name-format: 1
+  variable-name-format: 1
+
+  # Style Guide
+  pseudo-element: 0
+  bem-depth: 0
+  border-zero: 0
+  brace-style: 1
+  clean-import-paths: 1
+  empty-args: 1
+  hex-length: 1
+  hex-notation: 1
+  indentation: 1
+  leading-zero: 0
+  nesting-depth: 1
+  property-sort-order: 0
+  quotes:
+    - 2
+    -
+      style: double
+  shorthand-values: 0
+  url-quotes: 1
+  variable-for-property: 1
+  zero-unit: 1
+
+  # Inner Spacing
+  space-after-comma: 1
+  space-before-colon: 1
+  space-after-colon: 1
+  space-before-brace: 1
+  space-before-bang: 1
+  space-after-bang: 1
+  space-between-parens: 1
+  space-around-operator: 1
+
+  # Final Items
+  trailing-semicolon: 1
+  final-newline: 1

--- a/programs/sasslint/.sass-lint.yml
+++ b/programs/sasslint/.sass-lint.yml
@@ -63,7 +63,7 @@ rules:
   border-zero: 0
   brace-style: 1
   clean-import-paths: 1
-  empty-args: 1
+  empty-args: 0
   hex-length: 1
   hex-notation: 1
   indentation: 1
@@ -74,7 +74,7 @@ rules:
     - 2
     -
       style: double
-  shorthand-values: 0
+  shorthand-values: 1
   url-quotes: 1
   variable-for-property: 1
   zero-unit: 1

--- a/programs/sasslint/index.js
+++ b/programs/sasslint/index.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+const path = require("path")
+
+const command = path.join(process.cwd(), "node_modules", ".bin", "sass-lint")
+const baseArgs = [
+  "--config", path.join(__dirname, ".sass-lint.yml"),
+  "--verbose"
+]
+
+const sasslint = args => ({ command, args: baseArgs.concat(args) })
+
+module.exports = sasslint


### PR DESCRIPTION
Adding the new program `sasslint` which will... lint the sass files using [sass-lint](https://github.com/sasstools/sass-lint).

The ruleset is quite relaxed. I ran it against the Inugami code base and made some calls on disabling a few rules. We'll most probably add/remove/modify rules in the future.