### PR TITLE
Code splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "assets-webpack-plugin": "^3.5.0",
     "autoprefixer": "^6.4.0",
     "babel-core": "^6.14.0",
     "babel-eslint": "^6.1.2",

--- a/programs/compile/compile-with-webpack.js
+++ b/programs/compile/compile-with-webpack.js
@@ -29,18 +29,16 @@ function createCompiler(config) {
 
 function modifyForProduction(config, args) {
   config.devtool = "cheap-module-source-map"
-  config.plugins.push(
+  config.plugins = config.plugins.concat([
     new webpack.DefinePlugin({
       "process.env.NODE_ENV": JSON.stringify("production")
-    })
-  )
-  config.plugins.push(
+    }),
     new webpack.optimize.CommonsChunkPlugin({
-      names: ["vendor", "manifest"],
+      names: ["vendor"],
       minChunks: Infinity
-    })
-  )
-  config.plugins.push(new AssetsPlugin())
+    }),
+    new AssetsPlugin()
+  ])
 
   if (!args.includes("--no-uglify")) {
     config.plugins.push(

--- a/programs/compile/compile-with-webpack.js
+++ b/programs/compile/compile-with-webpack.js
@@ -1,5 +1,4 @@
 const webpack = require("webpack")
-const AssetsPlugin = require("assets-webpack-plugin")
 const devServer = require("./dev-server")
 const createWebpackConfig = require("./webpack.config")
 
@@ -29,16 +28,11 @@ function createCompiler(config) {
 
 function modifyForProduction(config, args) {
   config.devtool = "cheap-module-source-map"
-  config.plugins = config.plugins.concat([
+  config.plugins.push(
     new webpack.DefinePlugin({
       "process.env.NODE_ENV": JSON.stringify("production")
-    }),
-    new webpack.optimize.CommonsChunkPlugin({
-      names: ["vendor"],
-      minChunks: Infinity
-    }),
-    new AssetsPlugin()
-  ])
+    })
+  )
 
   if (!args.includes("--no-uglify")) {
     config.plugins.push(

--- a/programs/compile/compile-with-webpack.js
+++ b/programs/compile/compile-with-webpack.js
@@ -36,7 +36,8 @@ function modifyForProduction(config, args) {
   )
   config.plugins.push(
     new webpack.optimize.CommonsChunkPlugin({
-      names: ["vendor", "manifest"]
+      names: ["vendor", "manifest"],
+      minChunks: Infinity
     })
   )
   config.plugins.push(new AssetsPlugin())

--- a/programs/compile/compile-with-webpack.js
+++ b/programs/compile/compile-with-webpack.js
@@ -1,4 +1,5 @@
 const webpack = require("webpack")
+const AssetsPlugin = require("assets-webpack-plugin")
 const devServer = require("./dev-server")
 const createWebpackConfig = require("./webpack.config")
 
@@ -33,6 +34,12 @@ function modifyForProduction(config, args) {
       "process.env.NODE_ENV": JSON.stringify("production")
     })
   )
+  config.plugins.push(
+    new webpack.optimize.CommonsChunkPlugin({
+      names: ["vendor", "manifest"]
+    })
+  )
+  config.plugins.push(new AssetsPlugin())
 
   if (!args.includes("--no-uglify")) {
     config.plugins.push(

--- a/programs/compile/dev-server.js
+++ b/programs/compile/dev-server.js
@@ -5,11 +5,12 @@ const host = "0.0.0.0"
 const port = 8000
 
 const createDevServer = config => {
-  config.entry.unshift(
+  config.entry.main.unshift(
     `webpack-dev-server/client?http://${host}:${port}`,
     "webpack/hot/only-dev-server",
     "react-hot-loader/patch"
   )
+
   config.output.publicPath = `http://${host}:${port}/`
 
   config.plugins.push(new webpack.HotModuleReplacementPlugin())

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -1,7 +1,5 @@
 const ExtractTextPlugin = require("extract-text-webpack-plugin")
 const autoprefixer = require("autoprefixer")
-const webpack = require("webpack")
-const AssetsPlugin = require("assets-webpack-plugin")
 
 const createBabelOptions = args => {
   const babelConfig = {
@@ -136,11 +134,7 @@ function createWebpackConfig(args = [], opts = {}) {
       new ExtractTextPlugin({
         filename: opts.outputCss || "styles.css",
         allChunks: true
-      }),
-      new webpack.optimize.CommonsChunkPlugin({
-        names: ["vendor"]
-      }),
-      new AssetsPlugin()
+      })
     ],
     devServer: {
       inline: true,

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -150,7 +150,6 @@ function createWebpackConfig(args = [], opts = {}) {
   }
 
   if (opts.entry && opts.output) {
-    // config.entry = config.entry.concat([opts.entry])
     config.entry = {
       main: ["babel-polyfill", opts.entry]
     }

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -1,5 +1,6 @@
 const ExtractTextPlugin = require("extract-text-webpack-plugin")
 const autoprefixer = require("autoprefixer")
+const webpack = require("webpack")
 
 const createBabelOptions = args => {
   const babelConfig = {
@@ -134,6 +135,9 @@ function createWebpackConfig(args = [], opts = {}) {
       new ExtractTextPlugin({
         filename: opts.outputCss || "styles.css",
         allChunks: true
+      }),
+      new webpack.optimize.CommonsChunkPlugin({
+        names: ["vendor", "manifest"]
       })
     ],
     devServer: {
@@ -150,8 +154,15 @@ function createWebpackConfig(args = [], opts = {}) {
   }
 
   if (opts.entry && opts.output) {
-    config.entry = config.entry.concat([opts.entry])
+    // config.entry = config.entry.concat([opts.entry])
+    config.entry = {
+      main: ["babel-polyfill", opts.entry]
+    }
     config.output = opts.output
+  }
+
+  if (opts.vendor) {
+    config.entry.vendor = opts.vendor
   }
 
   if (opts.target) {

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -1,6 +1,7 @@
 const ExtractTextPlugin = require("extract-text-webpack-plugin")
 const autoprefixer = require("autoprefixer")
 const webpack = require("webpack")
+const AssetsPlugin = require("assets-webpack-plugin")
 
 const createBabelOptions = args => {
   const babelConfig = {
@@ -137,8 +138,9 @@ function createWebpackConfig(args = [], opts = {}) {
         allChunks: true
       }),
       new webpack.optimize.CommonsChunkPlugin({
-        names: ["vendor", "manifest"]
-      })
+        names: ["vendor"]
+      }),
+      new AssetsPlugin()
     ],
     devServer: {
       inline: true,

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -152,14 +152,20 @@ function createWebpackConfig(args = [], opts = {}) {
   }
 
   if (opts.entry && opts.output) {
+    const chunks = ["manifest"]
     config.entry = {
-      main: ["babel-polyfill", opts.entry],
-      vendor: opts.vendor ? opts.vendor : []
+      main: ["babel-polyfill", opts.entry]
     }
+
+    if (opts.vendor) {
+      config.entry.vendor = opts.vendor
+      chunks.push("vendor")
+    }
+
     config.output = opts.output
     config.plugins = config.plugins.concat([
       new webpack.optimize.CommonsChunkPlugin({
-        names: ["vendor", "manifest"],
+        names: chunks,
         minChunks: Infinity
       }),
       new AssetsPlugin()

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -153,13 +153,10 @@ function createWebpackConfig(args = [], opts = {}) {
 
   if (opts.entry && opts.output) {
     config.entry = {
-      main: ["babel-polyfill", opts.entry]
+      main: ["babel-polyfill", opts.entry],
+      vendor: opts.vendor ? opts.vendor : []
     }
     config.output = opts.output
-  }
-
-  if (opts.vendor && args.includes("--production")) {
-    config.entry.vendor = opts.vendor
     config.plugins = config.plugins.concat([
       new webpack.optimize.CommonsChunkPlugin({
         names: ["vendor", "manifest"],
@@ -167,6 +164,14 @@ function createWebpackConfig(args = [], opts = {}) {
       }),
       new AssetsPlugin()
     ])
+
+    if (args.includes("--dev-server")) {
+      // Dev server can't handle [chunkhash]
+      // this will make all files have the
+      // same [hash] but it doesn't matter
+      // in dev-server env
+      config.output.filename = "[hash].[name].js"
+    }
   }
 
   if (opts.target) {

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -1,5 +1,7 @@
 const ExtractTextPlugin = require("extract-text-webpack-plugin")
 const autoprefixer = require("autoprefixer")
+const webpack = require("webpack")
+const AssetsPlugin = require("assets-webpack-plugin")
 
 const createBabelOptions = args => {
   const babelConfig = {
@@ -156,8 +158,15 @@ function createWebpackConfig(args = [], opts = {}) {
     config.output = opts.output
   }
 
-  if (opts.vendor) {
+  if (opts.vendor && args.includes("--production")) {
     config.entry.vendor = opts.vendor
+    config.plugins = config.plugins.concat([
+      new webpack.optimize.CommonsChunkPlugin({
+        names: ["vendor", "manifest"],
+        minChunks: Infinity
+      }),
+      new AssetsPlugin()
+    ])
   }
 
   if (opts.target) {

--- a/programs/compile/webpack.config.test.js
+++ b/programs/compile/webpack.config.test.js
@@ -38,7 +38,7 @@ describe("createWebpackConfig()", () => {
 
       it("should set the entry", () => {
         // babel-polyfill is included automatically
-        expect(config.entry).toEqual(["babel-polyfill", "foo"])
+        expect(config.entry).toEqual({ main: ["babel-polyfill", "foo"] })
       })
 
       it("should set the javascript output", () => {

--- a/programs/compile/webpack.config.test.js
+++ b/programs/compile/webpack.config.test.js
@@ -38,8 +38,7 @@ describe("createWebpackConfig()", () => {
       })
 
       it("should set the entry", () => {
-        // babel-polyfill is included automatically
-        expect(config.entry).toEqual({ main: ["babel-polyfill", "foo"] })
+        expect(config.entry).toEqual({ main: ["babel-polyfill", "foo"], vendor: [] })
       })
 
       it("should set the javascript output", () => {
@@ -205,7 +204,7 @@ describe("createWebpackConfig()", () => {
   })
 
   describe("code splitting", () => {
-    it("includes chunk plugins for production when vendor exists", () => {
+    it("includes common chunk plugin", () => {
       const config = createWebpackConfig(["--production"], {
         vendor: ["foo", "bar"],
         output: "bundle.js",
@@ -214,17 +213,10 @@ describe("createWebpackConfig()", () => {
       const chunkPlugin = config.plugins.find(p => p instanceof webpack.optimize.CommonsChunkPlugin)
 
       expect(chunkPlugin).toBeDefined()
-      expect(config.entry.vendor).toEqual(["foo", "bar"])
-    })
-
-    it("exludes chunk plugins for production when vendor don't exist", () => {
-      const config = createWebpackConfig(["--production"], {
-        output: "bundle.js",
-        entry: "main.js"
-      }).build()
-      const chunkPlugin = config.plugins.find(p => p instanceof webpack.optimize.CommonsChunkPlugin)
-
-      expect(chunkPlugin).toBeUndefined()
+      expect(config.entry).toEqual({
+        main: ["babel-polyfill", "main.js"],
+        vendor: ["foo", "bar"]
+      })
     })
   })
 })

--- a/programs/compile/webpack.config.test.js
+++ b/programs/compile/webpack.config.test.js
@@ -38,7 +38,7 @@ describe("createWebpackConfig()", () => {
       })
 
       it("should set the entry", () => {
-        expect(config.entry).toEqual({ main: ["babel-polyfill", "foo"], vendor: [] })
+        expect(config.entry).toEqual({ main: ["babel-polyfill", "foo"] })
       })
 
       it("should set the javascript output", () => {

--- a/programs/compile/webpack.config.test.js
+++ b/programs/compile/webpack.config.test.js
@@ -1,4 +1,5 @@
 const createWebpackConfig = require("./webpack.config")
+const webpack = require("webpack")
 
 describe("createWebpackConfig()", () => {
   describe("with no options", () => {
@@ -200,6 +201,30 @@ describe("createWebpackConfig()", () => {
           presets: [["es2015", { loose: true }], "react", "stage-1"],
           plugins: [["__coverage__", { ignore: "*.test.js" }]]
         })
+    })
+  })
+
+  describe("code splitting", () => {
+    it("includes chunk plugins for production when vendor exists", () => {
+      const config = createWebpackConfig(["--production"], {
+        vendor: ["foo", "bar"],
+        output: "bundle.js",
+        entry: "main.js"
+      }).build()
+      const chunkPlugin = config.plugins.find(p => p instanceof webpack.optimize.CommonsChunkPlugin)
+
+      expect(chunkPlugin).toBeDefined()
+      expect(config.entry.vendor).toEqual(["foo", "bar"])
+    })
+
+    it("exludes chunk plugins for production when vendor don't exist", () => {
+      const config = createWebpackConfig(["--production"], {
+        output: "bundle.js",
+        entry: "main.js"
+      }).build()
+      const chunkPlugin = config.plugins.find(p => p instanceof webpack.optimize.CommonsChunkPlugin)
+
+      expect(chunkPlugin).toBeUndefined()
     })
   })
 })

--- a/programs/test/karma.conf.js
+++ b/programs/test/karma.conf.js
@@ -10,6 +10,7 @@ delete webpackConfig.output // The output is the test result
 delete webpackConfig.vendor // No vendor is needed
 webpackConfig.entry = jsEnvConfig.test.files
 webpackConfig.devtool = "inline-source-map" // Produces more quiet error output
+
 Object.assign(webpackConfig.externals, {
   "react/addons": true,
   "react/lib/ExecutionEnvironment": true,


### PR DESCRIPTION
@iZettle/web 

Code Splitting 🕺 

This will setup javascript-env to handle code-splitting. There is currently no opt-in/opt-out config for this so I'm thinking of making this a major release, **3.0.0**

#### Changes for javascript-env.js
```js
{
  compile: {
    entry: "path/to/entry/[chunkhash].[name].js"
    vendor: ["list", "of", "packages", "react", "react-dom", "moment", "etc"]
  }
}
```

This will yield something like:

Asset | Size | Chunks | Chunk Names
------|----- | --------|---------------
10d469949f71284c94ce.12.js | 951 bytes | 12, 23 | [emitted]
10d469949f71284c94ce.0.js | 119 kB | 0, 23 | [emitted]
10d469949f71284c94ce.2.js | 13.2 kB | 2, 23 | [emitted]
10d469949f71284c94ce.3.js | 15 kB | 3, 4, 23 | [emitted]
10d469949f71284c94ce.vendor.js | 4.08 MB | 14, 23 | [emitted]  [big]  vendor
10d469949f71284c94ce.main.js | 1.75 MB | 15, 23 | [emitted]  [big]  main
10d469949f71284c94ce.manifest.js | 30.1 kB | 23 | [emitted]         manifest

#### What files should i send on initial render
In your project root there is also a file named `webpack-asssets.json` with a content like this than can be parsed and then used to create script elements.

```json
{
  "vendor": {
    "js": "http://0.0.0.0:8000/10d469949f71284c94ce.vendor.js"
  },
  "main": {
    "js": "http://0.0.0.0:8000/10d469949f71284c94ce.main.js"
  },
  "manifest": {
    "js": "http://0.0.0.0:8000/10d469949f71284c94ce.manifest.js"
  }
}
```

###### Vendor
Mostly 3rd party packages, will almost never change

###### Main
Our application entry file

###### Manifest
Webpack runtime generated code, this will always get a new hash, that's why it's important to not have the manifest included inside of *vendor*