### PR TITLE
Fixes autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "assets-webpack-plugin": "^3.5.0",
-    "autoprefixer": "^6.4.0",
+    "autoprefixer": "^6.7.1",
     "babel-core": "^6.14.0",
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.5",
@@ -23,7 +23,7 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.13.0",
-    "css-loader": "^0.24.0",
+    "css-loader": "^0.26.1",
     "enzyme": "2.4.1",
     "eslint": "^3.3.1",
     "eslint-config-airbnb": "^10.0.1",
@@ -45,7 +45,7 @@
     "karma-teamcity-reporter": "^1.0.0",
     "karma-webpack": "^2.0.1",
     "node-sass": "^3.8.0",
-    "postcss-loader": "^0.10.1",
+    "postcss-loader": "^1.2.2",
     "raw-loader": "^0.5.1",
     "react": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
@@ -53,9 +53,9 @@
     "react-hot-loader": "^3.0.0-beta.6",
     "redux-mock-store": "^1.1.4",
     "sass-lint": "^1.10.2",
-    "sass-loader": "^4.0.0",
+    "sass-loader": "^4.1.1",
     "style-loader": "^0.13.1",
-    "webpack": "^2.2.0-rc.2",
-    "webpack-dev-server": "^2.2.0-rc.0"
+    "webpack": "^2.2.0",
+    "webpack-dev-server": "^2.2.0"
   }
 }

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -33,14 +33,7 @@ const createStyleLoader = (args, opts) => {
         localIdentName: "[local]---[hash:base64:5]"
       }
     }, {
-      loader: "postcss-loader",
-      options: {
-        plugins() {
-          return [
-            autoprefixer({ browsers: ["last 5 versions"] })
-          ]
-        }
-      }
+      loader: "postcss-loader"
     }, {
       loader: "sass-loader",
       query: {
@@ -101,14 +94,7 @@ function createWebpackConfig(args = [], opts = {}) {
         localIdentName: "[local]---[hash:base64:5]"
       }
     }, {
-      loader: "postcss-loader",
-      options: {
-        plugins() {
-          return [
-            autoprefixer({ browsers: ["last 5 versions"] })
-          ]
-        }
-      }
+      loader: "postcss-loader"
     }, {
       loader: "sass-loader",
       query: {
@@ -137,6 +123,20 @@ function createWebpackConfig(args = [], opts = {}) {
       new ExtractTextPlugin({
         filename: opts.outputCss || "styles.css",
         allChunks: true
+      }),
+      new webpack.LoaderOptionsPlugin({
+        minimize: args.includes("--production"),
+        debug: !args.includes("--production"),
+        options: {
+          // sass-loader throws if context isn't passed.
+          //
+          // "Some loaders need context information and read them from the configuration.
+          // This need to be passed via loader options in long-term.
+          // To keep compatibility with old loaders, this information can be passed here"
+          // - https://webpack.js.org/guides/migrating/
+          context: __dirname,
+          postcss: [autoprefixer({browsers: ["last 5 versions"]})]
+        }
       })
     ],
     devServer: {

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -134,7 +134,7 @@ function createWebpackConfig(args = [], opts = {}) {
           // This need to be passed via loader options in long-term.
           // To keep compatibility with old loaders, this information can be passed here"
           // - https://webpack.js.org/guides/migrating/
-          context: __dirname,
+          context: process.cwd(),
           postcss: [autoprefixer({browsers: ["last 5 versions"]})]
         }
       })

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -135,7 +135,7 @@ function createWebpackConfig(args = [], opts = {}) {
           // To keep compatibility with old loaders, this information can be passed here"
           // - https://webpack.js.org/guides/migrating/
           context: process.cwd(),
-          postcss: [autoprefixer({browsers: ["last 5 versions"]})]
+          postcss: [autoprefixer({ browsers: ["last 5 versions"] })]
         }
       })
     ],

--- a/programs/compile/webpack.config.test.js
+++ b/programs/compile/webpack.config.test.js
@@ -80,7 +80,7 @@ describe("createWebpackConfig()", () => {
 
       it("should be present in the sass loader config", () => {
         const loader = builder.config.module.rules.sass.loader
-        expect(loader).toMatch(/("includePaths":\["foo"])/g)
+        expect(loader.pop().query.includePaths).toEqual(["foo"])
       })
     })
 
@@ -93,7 +93,7 @@ describe("createWebpackConfig()", () => {
       it("should not be present in sassLoader", () => {
         const builder = createWebpackConfig()
         const loader = builder.config.module.rules.sass.loader
-        expect(loader).not.toMatch(/("includePaths":\["foo"])/)
+        expect(loader.pop().query.includePaths).not.toEqual(["foo"])
       })
     })
   })
@@ -178,7 +178,7 @@ describe("createWebpackConfig()", () => {
       expect(config.module.rules[0].use[0].options)
         .toEqual({ presets: [["es2015", { loose: true }], "react", "stage-1"], plugins: [] })
 
-      expect(config.module.rules[3].loader)
+      expect(config.module.rules[3].loader[0].loader)
         .toContain("extract-text-webpack-plugin/loader.js")
     })
 


### PR DESCRIPTION
Re-adds autoprefixer, which hasn't been working since the upgrade of Webpack to 2.0.

There's a possibility for regression errors as this adds the `LoaderOptionsPlugin`. As of Webpack 2, options for loaders should be passed with this plugin. However, of backwards compatibility reasons most loaders (but apparently not postcss/autoprefixer) also accepts the "old" way of passing options, **but**:

Some modules detects that `LoaderOptionsPlugin` is present and therefor read it's configs from there and disregards the old way. E.g.
* `minimize` must be present in `LoaderOptionsPlugin` for `uglify` to minimize
* `options.context` must be there for `sass-loader` to not throw.

Must be tested with Portal. Nothing else using this, right? (Inugami and Kitsune still uses ~2.0.0)

@iZettle/web 