### PR TITLE
CommonJS modules are no longer transpiled into commonjs modules

### DIFF
--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -5,7 +5,16 @@ const AssetsPlugin = require("assets-webpack-plugin")
 
 const createBabelOptions = args => {
   const babelConfig = {
-    presets: [["es2015", { loose: true }], "react", "stage-1"],
+    presets: [
+      [
+        "es2015", {
+         loose: true,
+         modules: false
+        }
+      ],
+      "react",
+      "stage-1"
+    ],
     plugins: []
   }
 


### PR DESCRIPTION
This seemingly small change makes it so that es-modules (`import x from...`) are no longer transpiled into CommonJS (`require(...)`) modules before handed off to Webpack.

As of Webpack 2, Webpack can natively understand es-modules, but more important, **only es6 modules can be tree shaken**.

What this means is: Tree shaking is now working and should shake away any non-connected branches from your build!