### PR TITLE
Configures Webpack to profile when running with --profile arg

### DIFF
--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -8,8 +8,8 @@ const createBabelOptions = args => {
     presets: [
       [
         "es2015", {
-         loose: true,
-         modules: false
+          loose: true,
+          modules: false
         }
       ],
       "react",

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -156,6 +156,7 @@ function createWebpackConfig(args = [], opts = {}) {
         chunkModules: false
       }
     },
+    profile: args.includes("--profile"),
     performance: {
       hints: false
     }

--- a/programs/compile/webpack.config.test.js
+++ b/programs/compile/webpack.config.test.js
@@ -176,7 +176,16 @@ describe("createWebpackConfig()", () => {
       const config = createWebpackConfig().build()
 
       expect(config.module.rules[0].use[0].options)
-        .toEqual({ presets: [["es2015", { loose: true, modules: false }], "react", "stage-1"], plugins: [] })
+        .toEqual({
+          presets: [
+            [
+              "es2015",
+              { loose: true, modules: false }
+            ],
+            "react",
+            "stage-1"],
+          plugins: []
+        })
 
       expect(config.module.rules[3].loader[0].loader)
         .toContain("extract-text-webpack-plugin/loader.js")
@@ -201,6 +210,16 @@ describe("createWebpackConfig()", () => {
           plugins: [["__coverage__", { ignore: "*.test.js" }]]
         })
     })
+  })
+
+  it("should work with profile flag", () => {
+    const config = createWebpackConfig(["--profile"]).build()
+    expect(config.profile).toEqual(true)
+  })
+
+  it("should work without profile flag", () => {
+    const config = createWebpackConfig().build()
+    expect(config.profile).toEqual(false)
   })
 
   describe("code splitting", () => {


### PR DESCRIPTION
When running with `--profile`, profiling is enabled in Webpack. What this means is that the `webpack-stats-x.json` file will contain timing information which can be seen when uploading the file to https://webpack.github.io/analyse/ It can be seen on each module and slow module chains can be seen when pressing "Hints" in the menu.