### PR TITLE
sourceMaps

### DIFF
--- a/programs/compile/compile-with-webpack.js
+++ b/programs/compile/compile-with-webpack.js
@@ -46,7 +46,8 @@ function modifyForProduction(config, args) {
       new webpack.optimize.UglifyJsPlugin({
         compress: { warnings: false },
         comments: false,
-        minimize: true
+        minimize: true,
+        sourceMap: true
       })
     )
   }

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -89,9 +89,11 @@ const createRules = (args, opts) => ({
 })
 
 function createWebpackConfig(args = [], opts = {}) {
+  const isProduction = () => args.includes("--production")
+  const useDevServer = () => args.includes("--dev-server")
   const rules = createRules(args, opts)
 
-  if (args.includes("--dev-server")) {
+  if (useDevServer()) {
     delete rules.sass.loader
     rules.sass.use = [{
       loader: "style-loader"
@@ -134,8 +136,9 @@ function createWebpackConfig(args = [], opts = {}) {
         allChunks: true
       }),
       new webpack.LoaderOptionsPlugin({
-        minimize: args.includes("--production"),
-        debug: !args.includes("--production"),
+        minimize: isProduction(),
+        debug: !isProduction(),
+        sourceMap: true,
         options: {
           // sass-loader throws if context isn't passed.
           //

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -89,11 +89,11 @@ const createRules = (args, opts) => ({
 })
 
 function createWebpackConfig(args = [], opts = {}) {
-  const isProduction = () => args.includes("--production")
-  const useDevServer = () => args.includes("--dev-server")
+  const isProduction = args.includes("--production")
+  const useDevServer = args.includes("--dev-server")
   const rules = createRules(args, opts)
 
-  if (useDevServer()) {
+  if (useDevServer) {
     delete rules.sass.loader
     rules.sass.use = [{
       loader: "style-loader"
@@ -136,8 +136,8 @@ function createWebpackConfig(args = [], opts = {}) {
         allChunks: true
       }),
       new webpack.LoaderOptionsPlugin({
-        minimize: isProduction(),
-        debug: !isProduction(),
+        minimize: isProduction,
+        debug: !isProduction,
         sourceMap: true,
         options: {
           // sass-loader throws if context isn't passed.


### PR DESCRIPTION
Create source maps for production builds. This is just to make errors from Sentry easier to debug.