### PR TITLE
Add the option to define definePlugin variables in javascript-env.js

### DIFF
--- a/config/example.js
+++ b/config/example.js
@@ -44,6 +44,12 @@ module.exports = {
           secure: false
         }
       }
+    },
+
+    // Define global variables which will be available in your
+    // entire codebase. E.g. for adding values from env vars.
+    define: {
+      "__MYHOST__": JSON.stringify(process.env.MYHOST)
     }
 
   },

--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -165,6 +165,12 @@ function createWebpackConfig(args = [], opts = {}) {
     }
   }
 
+  if (opts.define) {
+    config.plugins.push(
+      new webpack.DefinePlugin(opts.define)
+    )
+  }
+
   if (opts.entry && opts.output) {
     const chunks = ["manifest"]
     config.entry = {


### PR DESCRIPTION
The DefinePlugin allows you to create global constants which can be configured at compile time. This can be useful for allowing different behaviour between development builds and release builds. 

We're already using it today to  define production mode when in production mode (which is needed for a lot of modules to do a production grade compilation)

This extends that so that the user can define new variables which is needed for his/her code.
