### PR TITLE
Change eslint config to allow single quotes to avoid escape

### DIFF
--- a/programs/lint/.eslintrc.json
+++ b/programs/lint/.eslintrc.json
@@ -37,7 +37,7 @@
     "no-multiple-empty-lines": ["error", { "max": 1 }],
     "no-param-reassign": 0,
     "no-restricted-syntax": 0,
-    "quotes": [2, "double"],
+    "quotes": [2, "double", { "avoidEscape": true }],
     "react/jsx-closing-bracket-location": 0,
     "react/jsx-filename-extension": 0,
     "react/jsx-no-bind": 0,


### PR DESCRIPTION
Allows strings to use single-quotes or double-quotes so long as the string contains a quote that would have to be escaped otherwise, e.g.

```
const a = 'I "love" lamp'
```

Needed to be compatible with Prettier output

@iZettle/web 