### PR TITLE
Add setting to override default dev server port

### DIFF
--- a/config/example.js
+++ b/config/example.js
@@ -40,7 +40,10 @@ module.exports = {
           target: "http://0.0.0.0:3100",
           secure: false
         }
-      }
+      },
+
+      // Change from default dev server port 8000
+      port: 8001
     },
 
     // Define global variables which will be available in your

--- a/programs/compile/dev-server.js
+++ b/programs/compile/dev-server.js
@@ -2,9 +2,18 @@ const webpack = require("webpack")
 const WebpackDevServer = require("webpack-dev-server")
 
 const host = "0.0.0.0"
-const port = 8000
+const defaultPort = 8000
+
+const getPort = config => {
+  if (config.devServer && config.devServer.port) {
+    return config.devServer.port
+  }
+  return defaultPort
+}
 
 const createDevServer = config => {
+  const port = getPort(config)
+
   config.entry.main.unshift(
     `webpack-dev-server/client?http://${host}:${port}`,
     "webpack/hot/only-dev-server",
@@ -16,13 +25,16 @@ const createDevServer = config => {
 
   config.plugins.push(new webpack.HotModuleReplacementPlugin())
 
-  return new WebpackDevServer(webpack(config), config.devServer)
+  return {
+    webpackDevServer: new WebpackDevServer(webpack(config), config.devServer),
+    port
+  }
 }
 
 const startDevServer = devServer =>
-  devServer.listen(port, host, error => {
+  devServer.webpackDevServer.listen(devServer.port, host, error => {
     if (error) return console.log(error)
-    console.log(`Listening at http://${host}:${port}/`)
+    console.log(`Listening at http://${host}:${devServer.port}/`)
   })
 
 module.exports = config => startDevServer(createDevServer(config))


### PR DESCRIPTION
Needed to be able to run two projects with dev servers running at the same time.

@iZettle/web 