### PR TITLE
Make Webpack bail on errors in production build

### DIFF
--- a/programs/compile/webpack.config.js
+++ b/programs/compile/webpack.config.js
@@ -193,7 +193,8 @@ function createWebpackConfig(args = [], opts = {}) {
     profile: args.includes("--profile"),
     performance: {
       hints: false
-    }
+    },
+    bail: isProduction
   }
 
   if (opts.define) {


### PR DESCRIPTION
Fail out on the first Webpack error instead of tolerating it. By default Webpack will log these errors in red in the terminal but continue bundling. This can (and has...) give a broken build but where Heroku is all happy go lucky green...

@iZettle/web 